### PR TITLE
Ensure Digital Ocean tag exist and use it

### DIFF
--- a/modules/cloud-digitalocean/resources.tf
+++ b/modules/cloud-digitalocean/resources.tf
@@ -3,13 +3,17 @@ resource "digitalocean_ssh_key" "algo" {
   public_key = "${var.public_key_openssh}"
 }
 
+resource "digitalocean_tag" "algo" {
+  name = "Environment:Algo"
+}
+
 resource "digitalocean_droplet" "algo" {
   name      = "${var.algo_name}"
   image     = "${var.image}"
   size      = "${var.size}"
   region    = "${var.region}"
   user_data = "${var.user_data}"
-  tags      = [ "Environment:Algo" ]
+  tags      = [ "${digitalocean_tag.algo.id}" ]
   ssh_keys  = [ "${digitalocean_ssh_key.algo.id}" ]
   ipv6      = true
 }


### PR DESCRIPTION
Hello!

Thank you for creating Algo and experiment with a Terraform provisioning mechanism!

While peeking into the code and doing some testings, encountered the following issue.

---

Digital Ocean's provider indicates that `tags` references must exist prior it's usage. (docs [here](https://www.terraform.io/docs/providers/do/r/droplet.html)).

Attempt to provision of a non-existing tag results in 404 error, causing the provisioning process to abort.

This change ensures the tag is created (or noop if already exists) and associates it correctly to the instance.

---

With this change I was able to complete provisioning using Digital Ocean 😄 

Thank you again for creating and releasing Algo for the world to use!
❤️ ❤️ ❤️ 