### PR TITLE
Fixup ca_cert_pem namespace and cloud-init-sh location

### DIFF
--- a/modules/tls/output.tf
+++ b/modules/tls/output.tf
@@ -15,7 +15,7 @@
 # }
 
 output "ca_cert" {
-  value = "${tls_locally_signed_cert.ca.cert_pem}"
+  value = "${tls_locally_signed_cert.server.ca_cert_pem}"
 }
 
 output "server_cert" {

--- a/modules/user-data/main.tf
+++ b/modules/user-data/main.tf
@@ -1,5 +1,5 @@
 data "template_file" "cloud_init_vpn" {
-  template = "${file("${path.module}/../../scripts/cloud-init.sh")}"
+  template = "${file("${path.module}/../../cloud-init/cloud-init.sh")}"
 }
 
 data "template_cloudinit_config" "cloud_init" {


### PR DESCRIPTION
Working through a few issues prevent runs on `master`, this is the first one:
```
...
Workspace "digitalocean-nyc2-test-algo" doesn't exist.

You can create this workspace with the "new" subcommand.
Created and switched to workspace "digitalocean-nyc2-test-algo"!

You're now on a new, empty workspace. Workspaces isolate their state,
so if you run "terraform plan" Terraform will not see any existing state
for this configuration.
Initializing modules...
- module.main
  Getting source "../../modules/main/"
- module.user-data
  Getting source "../../modules/user-data/"
- module.tls
  Getting source "../../modules/tls/"

Error: output 'ca_cert': unknown resource 'tls_locally_signed_cert.ca' referenced in variable tls_locally_signed_cert.ca.cert_pem
....
```

And then, after adding https://github.com/trailofbits/algo-ng/pull/4/commits/35b9e2579c8a96d85e4c0eb41a8b92d9dd093f62 I got:
```
...
Initializing modules...
- module.main
- module.user-data
- module.tls

Initializing provider plugins...
- Checking for available provider plugins on https://releases.hashicorp.com...
- Downloading plugin for provider "null" (1.0.0)...
- Downloading plugin for provider "template" (1.0.0)...
- Downloading plugin for provider "tls" (1.2.0)...
- Downloading plugin for provider "local" (1.1.0)...

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.

Error: module.user-data.data.template_file.cloud_init_vpn: 1 error(s) occurred:

* module.user-data.data.template_file.cloud_init_vpn: file: open /Users/ghavil/Projects/algo-ng/.terraform/modules/283e0eb581d0a128c61daea7cdf6c1f2/../../scripts/cloud-init.sh: no such file or directory in:

${file("${path.module}/../../scripts/cloud-init.sh")}
...
``` 
which https://github.com/trailofbits/algo-ng/pull/4/commits/1ee5458209245c219365dc64061c67cb55d95b8e fixes. 

Signed-off-by: Jared Ledvina <jared@techsmix.net>